### PR TITLE
Fix a bug in the postcode schema

### DIFF
--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -567,7 +567,7 @@ components:
     postcode:
       name: UK postcode
       type: string
-      pattern: '^[A-Z]{1,2}[0-9][A-Z0-9]? ?[0-9][A-Z]{2}$'
+      pattern: '^[A-Z]{1,2}[0-9][A-Z0-9]? ?[0-9][A-Z]{2}$'
     address:
       name: Address
       type: object


### PR DESCRIPTION
 Fix the regular expression for postcodes, because it contained an `&nbsp;` Unicode character instead of a space.