### PR TITLE
Fix a bug on Windows where npm scripts would not always run properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   },
   "homepage": "https://github.com/nihruk/ioda#readme",
   "scripts": {
-    "docs": "./node_modules/.bin/http-server -o -p 8081 ./openapi/",
-    "test-ioda-specification": "./node_modules/.bin/validate-api ./openapi/index.yaml",
+    "docs": "bash -c './node_modules/.bin/http-server -o -p 8081 ./openapi/'",
+    "test-ioda-specification": "bash -c './node_modules/.bin/validate-api ./openapi/index.yaml'",
     "test": "npm run test-ioda-specification"
   },
   "dependencies": {


### PR DESCRIPTION
Fix a bug on Windows where npm scripts would not always run properly by forcing them to be run in Bash.

## How to test
- Run `npm run test` and `npm run docs` from the terminal on a Windows machine. Confirm there are no errors.