### PR TITLE
[WIP] Replace Redoc with Swagger UI

### DIFF
--- a/openapi/index.html
+++ b/openapi/index.html
@@ -1,19 +1,27 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>IODA API Documentation</title>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
-    <style>
-        body {
-            margin: 0;
-            padding: 0;
-        }
-    </style>
+    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@4.17.0/swagger-ui.css" />
+    <script src="https://unpkg.com/swagger-ui-dist@4.17.0/swagger-ui-bundle.js" crossorigin></script>
+    <script src="https://unpkg.com/swagger-ui-dist@4.17.0/swagger-ui-standalone-preset.js" crossorigin></script>
 </head>
 <body>
-<redoc spec-url="./index.yaml"></redoc>
-<script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
+  <div id="swagger-ui"></div>
+  <script>
+    window.onload = () => {
+      window.ui = SwaggerUIBundle({
+        url: './index.yaml',
+        dom_id: '#swagger-ui',
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIStandalonePreset
+        ],
+        layout: "StandaloneLayout",
+      });
+    };
+  </script>
 </body>
 </html>


### PR DESCRIPTION
Looks like there's been work on OpenAPI 3.1 support, but it's not done yet and Swagger UI 4.17 explicitly states the latest supported OpenAPI release is 3.0.x.