### PR TITLE
Fix date formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Visit https://ioda.vercel.app/ to view the latest stable documentation.
 Run `npm run docs` in a Git clone to see the absolute latest documentation of the checked out version.
 
 ## Development
-RUn `npm install`.
+Run `npm install`.
 
 ### QA
 Run `npm run test`.

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -742,13 +742,15 @@ components:
         start:
           title: Start date
           description: The date the research started.
-          type: full-date
+          type: string
+          format: date
           examples:
             - 1970-01-01
         end:
           title: End date
           description: The date the research ended.
-          type: full-date
+          type: string
+          format: date
           examples:
             - 2000-01-01
         funding:
@@ -808,13 +810,15 @@ components:
         start:
           title: Start date
           description: The date the call opened.
-          type: full-date
+          type: string
+          format: date
           examples:
             - 1970-01-01
         end:
           title: End date
           description: The date the call closed.
-          type: full-date
+          type: string
+          format: date
           examples:
             - 2000-01-01
         programStream:


### PR DESCRIPTION
Dates are generating a linting error in Swagger editor. From what I can see the dates are in 'full-date' format.
My understanding is the according to the Open API spec they should be in 'string' format with a 'date' modifier
The date modifier used in OpenAPI is 'full-date' described [here](https://swagger.io/docs/specification/data-models/data-types/#String%20Formats:~:text=pattern%20is%20specified.-,String%20Formats,-An%20optional%20format)

The changes made in the commit reflect this and resolve the linting error
