### PR TITLE
Refine the coding standard

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -4,7 +4,10 @@
     <file>src</file>
     <file>tests/src</file>
     <rule ref="PSR12"/>
-    <rule ref="Generic.Files.LineEndings">
-        <exclude name="Generic.Files.LineEndings.InvalidEOLChar"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
+        <properties>
+            <property name="spacesCountAroundEqualsSign" value="0"/>
+        </properties>
     </rule>
+    <rule ref="Squiz.Strings.DoubleQuoteUsage"/>
 </ruleset>

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^9.5",
         "psalm/plugin-phpunit": "^0.18.4",
+        "slevomat/coding-standard": "^8.12.1",
         "squizlabs/php_codesniffer": "^3.7",
         "symfony/browser-kit": "6.2.*",
         "symfony/css-selector": "6.2.*",
@@ -29,7 +30,8 @@
         "allow-plugins": {
             "php-http/discovery": true,
             "symfony/flex": true,
-            "symfony/runtime": true
+            "symfony/runtime": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
         },
         "sort-packages": true
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7a24cde2ab988c09db7a58376ca1e9f5",
+    "content-hash": "d92951212967951fde4d900f80d8ee60",
     "packages": [
         {
             "name": "psr/cache",
@@ -2821,6 +2821,84 @@
             "time": "2022-02-25T21:32:43+00:00"
         },
         {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "4be43904336affa5c2f70744a348312336afd0da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/4be43904336affa5c2f70744a348312336afd0da",
+                "reference": "4be43904336affa5c2f70744a348312336afd0da",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
+            },
+            "time": "2023-01-05T11:28:13+00:00"
+        },
+        {
             "name": "dnoegel/php-xdg-base-dir",
             "version": "v0.1.1",
             "source": {
@@ -3741,24 +3819,22 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.22.0",
+            "version": "1.20.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "ec58baf7b3c7f1c81b3b00617c953249fb8cf30c"
+                "reference": "7d568c87a9df9c5f7e8b5f075fc469aa8cb0a4cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/ec58baf7b3c7f1c81b3b00617c953249fb8cf30c",
-                "reference": "ec58baf7b3c7f1c81b3b00617c953249fb8cf30c",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/7d568c87a9df9c5f7e8b5f075fc469aa8cb0a4cd",
+                "reference": "7d568c87a9df9c5f7e8b5f075fc469aa8cb0a4cd",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0"
             },
             "require-dev": {
-                "doctrine/annotations": "^2.0",
-                "nikic/php-parser": "^4.15",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/extension-installer": "^1.0",
                 "phpstan/phpstan": "^1.5",
@@ -3782,9 +3858,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.22.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.20.4"
             },
-            "time": "2023-06-01T12:35:21+00:00"
+            "time": "2023-05-02T09:19:37+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -5292,6 +5368,71 @@
                 }
             ],
             "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
+            "name": "slevomat/coding-standard",
+            "version": "8.12.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "f69e2524e8770efb9b3e5ac4a0ebc0d54eb446d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/f69e2524e8770efb9b3e5ac4a0ebc0d54eb446d7",
+                "reference": "f69e2524e8770efb9b3e5ac4a0ebc0d54eb446d7",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpdoc-parser": ">=1.20.0 <1.21.0",
+                "squizlabs/php_codesniffer": "^3.7.1"
+            },
+            "require-dev": {
+                "phing/phing": "2.17.4",
+                "php-parallel-lint/php-parallel-lint": "1.3.2",
+                "phpstan/phpstan": "1.10.15",
+                "phpstan/phpstan-deprecation-rules": "1.1.3",
+                "phpstan/phpstan-phpunit": "1.3.11",
+                "phpstan/phpstan-strict-rules": "1.5.1",
+                "phpunit/phpunit": "7.5.20|8.5.21|9.6.8|10.1.3"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "keywords": [
+                "dev",
+                "phpcs"
+            ],
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/8.12.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-05-15T21:42:25+00:00"
         },
         {
             "name": "spatie/array-to-xml",

--- a/psalm.xml
+++ b/psalm.xml
@@ -9,11 +9,12 @@
 >
     <projectFiles>
         <directory name="src"/>
-        <directory name="tests"/>
-
+        <directory name="tests/src"/>
         <ignoreFiles>
             <directory name="vendor"/>
             <file name="tests/bootstrap.php"/>
         </ignoreFiles>
     </projectFiles>
-<plugins><pluginClass class="Psalm\PhpUnitPlugin\Plugin"/></plugins></psalm>
+<plugins>
+    <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/></plugins>
+</psalm>

--- a/src/Controller/ContentNegotiationController.php
+++ b/src/Controller/ContentNegotiationController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -10,25 +12,25 @@ use App\Controller\Tangerine;
 #[Route('/api', name: 'api_')]
 class ContentNegotiationController extends AbstractController
 {
-    #[Route('/pirates', name: 'pirates_index', methods: ["GET"])]
+    #[Route('/pirates', name: 'pirates_index', methods: ['GET'])]
     public function bar(): Response
     {
 
         $data = [];
         $ids = [0, 1, 2, 3, 4];
-        $names = ["Long John", "Cockle Jim", "Barnacle Bob", "Doubloon Doug", "Seasick Steve"];
+        $names = ['Long John', 'Cockle Jim', 'Barnacle Bob', 'Doubloon Doug', 'Seasick Steve'];
         $descriptions = [
-            "Can drift for days",
-            "Treasure finder",
-            "Stuck to the ship",
-            "A rare gem",
-            "Always in the drink"
+            'Can drift for days',
+            'Treasure finder',
+            'Stuck to the ship',
+            'A rare gem',
+            'Always in the drink'
         ];
 
         foreach ($ids as $id) {
             $data[] = [
                 'id' => $id,
-                'ref' => "PRT",
+                'ref' => 'PRT',
                 'name' => $names[$id],
                 'description' => $descriptions[$id]
             ];
@@ -36,20 +38,20 @@ class ContentNegotiationController extends AbstractController
         return $this->json($data);
     }
 
-    #[Route('/pirates/text', name: 'pirates_text', methods: ["GET"])]
+    #[Route('/pirates/text', name: 'pirates_text', methods: ['GET'])]
     public function boo(): Response
     {
 
-        $textResponse = new Response("Pirates!", 200);
+        $textResponse = new Response('Pirates!', 200);
         $textResponse->headers->set('Content-Type', 'text/plain');
 
         return $textResponse;
     }
 
-    #[Route('/five-hundred', name: 'five_index', methods: ["POST"])]
+    #[Route('/five-hundred', name: 'five_index', methods: ['POST'])]
     public function fiveHundred(): Response
     {
-        $tangerine = "mandarins";
+        $tangerine = 'mandarins';
 
         throw new Tangerine($tangerine);
     }

--- a/src/Controller/Tangerine.php
+++ b/src/Controller/Tangerine.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Controller;
 
 use Exception;
@@ -13,10 +15,10 @@ class Tangerine extends Exception
     public function __construct(string $tangerineName)
     {
         self::$tangerineWithError = $tangerineName;
-        parent::__construct("The provided resource could not be handled.");
+        parent::__construct('The provided resource could not be handled.');
     }
     public static function customMessage(): void
     {
-        echo "Tangerine with error is - " . self::$tangerineWithError . " \n";
+        echo 'Tangerine with error is - ' . self::$tangerineWithError . " \n";
     }
 }

--- a/src/EventListener/RequestListener.php
+++ b/src/EventListener/RequestListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\EventListener;
 
 use Symfony\Component\HttpFoundation\AcceptHeader;
@@ -26,10 +28,10 @@ class RequestListener
     public function __construct(
         private LoggerInterface $logger,
         string $environment,
-        private string|null $accepts = ""
+        private string|null $accepts = ''
     ) {
         $this->environment = $environment;
-        $this->acceptable = array("text/html", "application/json");
+        $this->acceptable = array('text/html', 'application/json');
     }
 
     private function jsonValidator(mixed $data): bool
@@ -49,7 +51,7 @@ class RequestListener
         $request = $event->getRequest();
         $accept = AcceptHeader::fromString($request->headers->get('Accept'));
         $this->logger->info((string)json_encode($accept));
-        $intersect = array_intersect($this->acceptable, explode(",", $accept->__toString()));
+        $intersect = array_intersect($this->acceptable, explode(',', $accept->__toString()));
         $this->accepts = preg_replace('/\s+/', '', !empty($intersect) ? (string)$accept : (string)$this->accepts);
     }
 
@@ -67,7 +69,7 @@ class RequestListener
         $intersect  = $interText || $interJson;
 
         if (!$intersect) {
-            throw new NotAcceptableHttpException("IODA is only accepting {$accept_string} at present!");
+            throw new NotAcceptableHttpException('IODA is only accepting ' . $accept_string . ' at present!');
         } else {
             $isJson = $this->jsonValidator($content);
             if ($isJson && !$interJson) {

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App;
 
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;

--- a/tests/src/Integration/Controller/ContentNegotiationControllerTest.php
+++ b/tests/src/Integration/Controller/ContentNegotiationControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\Integration\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -15,7 +17,7 @@ class ContentNegotiationControllerTest extends WebTestCase
             [],
             [],
             [
-                'HTTP_ACCEPT' => "application/json"
+                'HTTP_ACCEPT' => 'application/json'
             ]
         );
         $this->assertResponseIsSuccessful();
@@ -31,7 +33,7 @@ class ContentNegotiationControllerTest extends WebTestCase
             [],
             [],
             [
-                'HTTP_ACCEPT' => "application/json"
+                'HTTP_ACCEPT' => 'application/json'
             ]
         );
         $response = $client->getResponse();
@@ -48,7 +50,7 @@ class ContentNegotiationControllerTest extends WebTestCase
             [],
             [],
             [
-                'HTTP_ACCEPT' => "text/xml"
+                'HTTP_ACCEPT' => 'text/xml'
             ]
         );
         $response = $client->getResponse();
@@ -67,7 +69,7 @@ class ContentNegotiationControllerTest extends WebTestCase
             [],
             [],
             [
-                'HTTP_ACCEPT' => "application/json"
+                'HTTP_ACCEPT' => 'application/json'
             ]
         );
         $response = $client->getResponse();
@@ -85,7 +87,7 @@ class ContentNegotiationControllerTest extends WebTestCase
             [],
             [],
             [
-                'HTTP_ACCEPT' => "application/json"
+                'HTTP_ACCEPT' => 'application/json'
             ]
         );
         $response = $client->getResponse();

--- a/tests/src/Unit/UnitTestsAreRunningTest.php
+++ b/tests/src/Unit/UnitTestsAreRunningTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
- Require strict typing
- Standardize on single quotes, and enabling strict checking of double-quoted strings to avoid pitfalls with embedded variables
- No longer allow CRLF (`\r\n`) line endings but standardize on LF ( `\n`) so we are again PSR-12 compliant